### PR TITLE
Refactoring using more functional style

### DIFF
--- a/Sources/RingSig/Extensions.swift
+++ b/Sources/RingSig/Extensions.swift
@@ -24,10 +24,7 @@ extension BigUInt {
   public func bytesWithPadding(to bytesCount: Int) -> Array<UInt8> {
     let bytes = self.serialize().bytes
     let paddingBytes = bytesCount - bytes.count
-    var padding = Array<UInt8>()
-    for _ in 0..<paddingBytes {
-      padding += [0]
-    }
+    let padding = Array<UInt8>(repeating: 0, count: paddingBytes)
     return padding + bytes
   }
 

--- a/Sources/RingSig/RingSig.swift
+++ b/Sources/RingSig/RingSig.swift
@@ -80,9 +80,8 @@ public class RingSig {
     precondition(signature.publicKeys.count == signature.xValues.count)
     // 1. Apply the trap-door permutations
     let commonModulus = commonB(publicKeys: signature.publicKeys)
-    var yValues: [BigUInt] = []
-    for index in 0..<signature.publicKeys.count {
-      yValues.append(g(x: signature.xValues[index], publicKey: signature.publicKeys[index], commonModulus: commonModulus))
+    let yValues: [BigUInt] = zip(signature.xValues, signature.publicKeys).map { (x, publicKey) in
+        return g(x: x, publicKey: publicKey, commonModulus: commonModulus)
     }
     // 2. Compute the key as k = h(m)
     let k = calculateDigest(message: message)


### PR DESCRIPTION
Remove the necessity of creating `var` arrays to add elements in a loop by using the initialiser `init(repeating: T, count: Int` and the `zip` method.